### PR TITLE
[Fix] Place API 컨트롤러의 ApiResponse 제네릭 타입 불일치 수정

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.kt
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.kt
@@ -25,7 +25,7 @@ class PlaceController(
         @RequestParam(required = false) radiusKm: Int?,
         @RequestParam(required = false) category2: List<Category2Type>?,
         @RequestParam(required = false) keyword: String?
-    ): ResponseEntity<ApiResponse<List<PlaceSearchResponse>>> {
+    ): ResponseEntity<ApiResponse<List<PlaceSearchResponse>?>> {
 
         val results = placeService.searchPlaces(lat, lon, radiusKm, category2, keyword)
         return ResponseEntity.ok(ApiResponse.success(results))
@@ -34,7 +34,7 @@ class PlaceController(
     @GetMapping("/{placeId}")
     override fun getPlaceDetail(
         @PathVariable @Positive placeId: Long
-    ): ResponseEntity<ApiResponse<PlaceDetailResponse>> {
+    ): ResponseEntity<ApiResponse<PlaceDetailResponse?>> {
         val detail = placeService.getPlaceDetail(placeId)
         return ResponseEntity.ok(ApiResponse.success(detail))
     }

--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.kt
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.kt
@@ -69,7 +69,7 @@ interface PlaceSpecification {
             example = "동물병원"
         )
         keyword: String?
-    ): ResponseEntity<ApiResponse<List<PlaceSearchResponse>>>
+    ): ResponseEntity<ApiResponse<List<PlaceSearchResponse>?>>
 
     @ApiErrorCodeExamples(ErrorCode.NOT_FOUND_PLACE)
     @Operation(summary = "장소 상세 조회", description = "장소 ID로 상세 정보를 조회합니다.")
@@ -81,5 +81,5 @@ interface PlaceSpecification {
         )
         @Positive
         placeId: Long
-    ): ResponseEntity<ApiResponse<PlaceDetailResponse>>
+    ): ResponseEntity<ApiResponse<PlaceDetailResponse?>>
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #29 

## 📝 변경 사항
### AS-IS
- `ApiResponse`가 Kotlin으로 마이그레이션되면서 `success(data: T?)`의 반환 타입이 `ApiResponse<T?>`로 정의됨.
- 하지만 `PlaceSpecification`과 `PlaceController`는 여전히 다음과 같이 **non-null 제네릭 타입**을 사용 중이었음:
  - `ResponseEntity<ApiResponse<List<PlaceSearchResponse>>>`
  - `ResponseEntity<ApiResponse<PlaceDetailResponse>>`
- 이로 인해 `ApiResponse.success(results)` / `ApiResponse.success(detail)` 호출 시  
  `ApiResponse<List<PlaceSearchResponse>?>` vs `ApiResponse<List<PlaceSearchResponse>>` 형태의 제네릭 타입 불일치로 컴파일 오류 발생.


### TO-BE
- **PlaceSpecification**
  - `searchPlaces` 반환 타입을 `ResponseEntity<ApiResponse<List<PlaceSearchResponse>?>>`로 변경
  - `getPlaceDetail` 반환 타입을 `ResponseEntity<ApiResponse<PlaceDetailResponse?>>`로 변경
  - 새로운 `ApiResponse` 설계(`data: T?`, `success(): ApiResponse<T?>`)와 정확히 일치하도록 타입 정리

- **PlaceController**
  - 인터페이스와 동일하게 반환 타입을 다음과 같이 수정:
    - `ResponseEntity<ApiResponse<List<PlaceSearchResponse>?>>`
    - `ResponseEntity<ApiResponse<PlaceDetailResponse?>>`
  - 내부 서비스 호출(`placeService.searchPlaces`, `placeService.getPlaceDetail`)은 기존처럼 non-null 값을 반환하도록 유지
  - 응답 래핑 타입(ApiResponse)의 **제네릭 부분만 nullable**로 맞춰 타입 시스템과 충돌 없이 동작하도록 변경

- **공통**
  - 비즈니스 로직(반경 검색, 상세 조회)에는 손대지 않고,  
    ApiResponse 마이그레이션으로 인해 발생한 제네릭 시그니처 불일치만 해결


## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- `ApiResponse<T>`의 제네릭 설계(`data: T?`, `success(): ApiResponse<T?>`)에 맞춰  
  Place API의 반환 타입만 정리했습니다.


