### PR TITLE
Migration/migrating testcodes for mypage pet domain

### DIFF
--- a/backend/src/test/java/com/backend/petplace/domain/mypage/service/MyPageServiceTest.kt
+++ b/backend/src/test/java/com/backend/petplace/domain/mypage/service/MyPageServiceTest.kt
@@ -45,6 +45,7 @@ class MyPageServiceTest {
     @BeforeEach
     fun init() {
         user = User(
+            id = 1L,
             nickName = "user1",
             email = "user1@example.com",
             password = "pwd",

--- a/backend/src/test/java/com/backend/petplace/domain/mypage/service/MyPageServiceTest.kt
+++ b/backend/src/test/java/com/backend/petplace/domain/mypage/service/MyPageServiceTest.kt
@@ -1,0 +1,107 @@
+package com.backend.petplace.domain.mypage.service
+
+import com.backend.petplace.domain.mypage.dto.MyPageUserPets
+import com.backend.petplace.domain.mypage.dto.MyPageUserPoints
+import com.backend.petplace.domain.mypage.dto.response.MyPageResponse
+import com.backend.petplace.domain.pet.entity.Gender
+import com.backend.petplace.domain.pet.repository.PetRepository
+import com.backend.petplace.domain.point.entity.PointDescription
+import com.backend.petplace.domain.point.repository.PointRepository
+import com.backend.petplace.domain.review.dto.response.MyReviewResponse
+import com.backend.petplace.domain.review.repository.ReviewRepository
+import com.backend.petplace.domain.review.service.S3Service
+import com.backend.petplace.domain.user.entity.User
+import com.backend.petplace.domain.user.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.BDDMockito.given
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class MyPageServiceTest {
+
+    @Mock private lateinit var userRepository: UserRepository
+    @Mock private lateinit var pointRepository: PointRepository
+    @Mock private lateinit var reviewRepository: ReviewRepository
+    @Mock private lateinit var petRepository: PetRepository
+    @Mock private lateinit var s3Service: S3Service
+
+    @InjectMocks
+    private lateinit var myPageService: MyPageService
+
+    private lateinit var user: User
+    private val cloudFrontDomain = "https://cloudfront-test.com" // 테스트 할 때는 직접 하드코딩 한다고 합니다
+
+    @BeforeEach
+    fun init() {
+        user = User(
+            nickName = "user1",
+            email = "user1@example.com",
+            password = "pwd",
+            address = "주소",
+            addressDetail = "주소2",
+            zipcode = "11111"
+        )
+
+        userRepository.save(user)
+    }
+
+    @Test
+    @DisplayName("마이페이지 조회 - earnablePoints 계산 및 DTO 조립 검증")
+    fun myPageTest() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(user))
+
+        // 오늘 획득한 포인트
+        given(pointRepository.findTodaysPointsSumByUser(eq(user), any()))
+            .willReturn(900)
+
+        // 포인트 내역
+        given(pointRepository.findMyPagePointHistory(user))
+            .willReturn(listOf(MyPageUserPoints(1L, PointDescription.REVIEW_PHOTO, 100, LocalDateTime.now())))
+
+        // 리뷰 + S3 URL
+        val review = MyReviewResponse(1L, 1L, "장소 이름", "주소", 5, "30자 적은 리뷰 글", "image.png", LocalDateTime.now(), 100)
+        given(reviewRepository.findMyReviewsWithProjection(user))
+            .willReturn(listOf(review))
+
+        // URL 조합
+        given(s3Service.getPublicUrl("image.png"))
+            .willReturn("$cloudFrontDomain/image.png")
+
+        // 펫 목록
+        given(petRepository.findByUserWithActivatedPet(user))
+            .willReturn(listOf(MyPageUserPets(1L, "뚜뚜", Gender.Female, LocalDate.of(2021, 1, 1), "말티즈")))
+
+        // when
+        val response: MyPageResponse = myPageService.myPage(1L)
+
+        // then
+        // 유저 정보
+        assertThat(response.userInfo.id).isEqualTo(1L)
+        assertThat(response.userInfo.earnablePoints).isEqualTo(100) // 1000 - 900
+        assertThat(response.reviews.size).isEqualTo(1)
+
+        // 리뷰 검증
+        val firstReview = response.reviews.first()
+        assertThat(firstReview.reviewId).isEqualTo(1L)
+        assertThat(firstReview.place.placeId).isEqualTo(1L)
+        assertThat(firstReview.pointsAwarded).isEqualTo(100)
+        assertThat(firstReview.imageUrl).isEqualTo("$cloudFrontDomain/image.png")
+
+        // 반려동물
+        val pet = response.pets.first()
+        assertThat(pet.id).isEqualTo(1L)
+        assertThat(pet.name).isEqualTo("뚜뚜")
+    }
+}

--- a/backend/src/test/java/com/backend/petplace/domain/pet/service/PetServiceTest.kt
+++ b/backend/src/test/java/com/backend/petplace/domain/pet/service/PetServiceTest.kt
@@ -1,0 +1,121 @@
+package com.backend.petplace.domain.pet.service
+
+import com.backend.petplace.domain.pet.dto.request.CreatePetRequest
+import com.backend.petplace.domain.pet.dto.request.UpdatePetRequest
+import com.backend.petplace.domain.pet.dto.response.CreatePetResponse
+import com.backend.petplace.domain.pet.entity.Gender
+import com.backend.petplace.domain.pet.entity.Pet
+import com.backend.petplace.domain.pet.repository.PetRepository
+import com.backend.petplace.domain.user.entity.User
+import com.backend.petplace.domain.user.repository.UserRepository
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@DataJpaTest //단위 테스트 - 통합 테스트 시 SpringBootTest 어노테이션으로 교체
+@Import(PetService::class)
+@Transactional
+class PetServiceTest {
+
+    @Autowired
+    private lateinit var petService: PetService
+
+    @Autowired
+    private lateinit var petRepository: PetRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @PersistenceContext
+    private lateinit var em: EntityManager
+
+    private lateinit var user: User
+
+    @BeforeEach
+    fun init() {
+        user = User(
+            nickName = "user1",
+            email = "user1@example.com",
+            password = "pwd",
+            address = "주소",
+            addressDetail = "주소2",
+            zipcode = "11111"
+        )
+
+        userRepository.save(user)
+    }
+
+    @Test
+    @DisplayName("펫 생성")
+    fun createPet() {
+        // given
+        val request = CreatePetRequest("뚜뚜", Gender.Female.toString(), LocalDate.of(2022, 1, 1), "말티즈")
+
+        // when
+        val response: CreatePetResponse = petService.createPet(user.id!!, request)
+        val saved: Pet = petRepository.findById(response.id).orElseThrow()
+
+        // then
+        assertThat(saved.name).isEqualTo("뚜뚜")
+        assertThat(saved.gender).isEqualTo(Gender.Female)
+        assertThat(saved.birthDate).isEqualTo(LocalDate.of(2022, 1, 1))
+        assertThat(saved.type).isEqualTo("말티즈")
+        assertThat(saved.user?.id).isEqualTo(user.id)
+    }
+
+    @Test
+    @DisplayName("펫 수정")
+    fun updatePet() {
+        // given
+        val createRequest = CreatePetRequest("뚜뚜", Gender.Female.toString(), LocalDate.of(2022, 1, 1), "말티즈")
+
+        val createResponse = petService.createPet(user.id!!, createRequest)
+        val saved: Pet = petRepository.findById(createResponse.id).orElseThrow()
+
+        // when
+        val updateRequest = UpdatePetRequest("두두", Gender.Male.toString(), LocalDate.of(2021, 1, 1), "웰시코기")
+
+        petService.updatePet(user.id!!, saved.id!!, updateRequest)
+
+        em.flush()
+        em.clear()
+
+        val updated: Pet = petRepository.findById(saved.id!!).orElseThrow()
+
+        // then
+        assertThat(updated.name).isEqualTo("두두")
+        assertThat(updated.gender).isEqualTo(Gender.Male)
+        assertThat(updated.birthDate).isEqualTo(LocalDate.of(2021, 1, 1))
+        assertThat(updated.type).isEqualTo("웰시코기")
+        assertThat(updated.user?.id).isEqualTo(user.id)
+    }
+
+    @Test
+    @DisplayName("펫 삭제")
+    fun deletePet() {
+        // given
+        val request = CreatePetRequest("뚜뚜", Gender.Female.toString(), LocalDate.of(2022, 1, 1), "말티즈")
+
+        val response = petService.createPet(user.id!!, request)
+        val saved: Pet = petRepository.findById(response.id).orElseThrow()
+
+        // when
+        petService.deletePet(user.id!!, saved.id!!)
+
+        em.flush()
+        em.clear()
+
+        val deleted: Pet = petRepository.findById(saved.id!!).orElseThrow()
+
+        // then
+        assertThat(deleted.isActivated()).isFalse()
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #46 

## 📝 변경 사항
### AS-IS
- kotlin에서의 mypage, pet 도메인 테스트코드 누락

### TO-BE
- 기존 java로 개발했던 test코드를 kotlin환경에서도 돌아가도록 kotlin파일로 변환

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
코틀린 - 마이페이지 도메인
<img width="1769" height="606" alt="image" src="https://github.com/user-attachments/assets/142a7e65-0a64-4ac6-9130-71f53c4ebef3" />

코틀린 - 반려동물 도메인
<img width="1760" height="472" alt="image" src="https://github.com/user-attachments/assets/b746e4a6-c779-4424-97d3-b9eeb992b29a" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
자바 코드에서 코틀린으로 그냥 옮긴거라고 보시면 됩니다!
로직에 대한 변경점은 없습니다!


