### PR TITLE
[Migration] 리뷰 도메인 테스트 전체 마이그레이션

### DIFF
--- a/backend/src/test/java/com/backend/petplace/domain/review/dto/ReviewInfoTest.kt
+++ b/backend/src/test/java/com/backend/petplace/domain/review/dto/ReviewInfoTest.kt
@@ -1,0 +1,47 @@
+package com.backend.petplace.domain.review.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class ReviewInfoTest {
+
+    private fun createDummy(): ReviewInfo {
+        return ReviewInfo(
+            reviewId = 1L,
+            userName = "TestUser",
+            content = "ReviewInfoDtoTest입니다.",
+            rating = 4,
+            imageUrl = "reviews/dummy-image-key.jpg", // S3 Path
+            createdDate = LocalDate.now()
+        )
+    }
+
+    @Test
+    @DisplayName("withFullImageUrl: S3 경로를 CloudFront URL로 교체")
+    fun withFullImageUrl() {
+
+        // given
+        val originalDto = createDummy()
+        val expectedCloudFrontUrl = "https://test.cloudfront.net"
+        val originalS3Path = originalDto.imageUrl
+        val expectedFullImageUrl = expectedCloudFrontUrl + "/" + originalS3Path
+
+        // when
+        val resultDto = ReviewInfo.withFullImageUrl(originalDto, expectedFullImageUrl)
+
+        // then
+        // 새로운 객체인지 확인
+        assertThat(resultDto).isNotSameAs(originalDto)
+
+        assertThat(resultDto.reviewId).isEqualTo(originalDto.reviewId)
+        assertThat(resultDto.userName).isEqualTo(originalDto.userName)
+        assertThat(resultDto.content).isEqualTo(originalDto.content)
+        assertThat(resultDto.rating).isEqualTo(originalDto.rating)
+
+        // URL 교체되었는지 확인
+        assertThat(resultDto.imageUrl).isEqualTo(expectedFullImageUrl)
+        assertThat(resultDto.createdDate).isEqualTo(LocalDate.now())
+    }
+}

--- a/backend/src/test/java/com/backend/petplace/domain/review/entity/ReviewTest.kt
+++ b/backend/src/test/java/com/backend/petplace/domain/review/entity/ReviewTest.kt
@@ -1,0 +1,56 @@
+package com.backend.petplace.domain.review.entity
+
+import com.backend.petplace.domain.place.entity.Category1Type
+import com.backend.petplace.domain.place.entity.Category2Type
+import com.backend.petplace.domain.place.entity.Place
+import com.backend.petplace.domain.user.entity.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class ReviewTest {
+
+    @Test
+    @DisplayName("createNewReview: 필수 필드를 포함하여 새로운 Review 엔티티 생성")
+    fun createNewReview() {
+
+        // given
+        val mockUser = User(
+            email = "testuser@example.com",
+            password = "testpassword123",
+            nickName = "TestUser",
+            address = "서울 강남구",
+            zipcode = "01234",
+            addressDetail = "101호" // Nullable 필드
+        )
+
+        val mockPlace = Place(
+            id = 1L,
+            uniqueKey = "PLACE_UK_1", // 필수 필드
+            name = "TestPlace",
+            category1 = Category1Type.ETC,
+            category2 = Category2Type.ETC,
+            latitude = 37.5,
+            longitude = 127.0,
+            address = "123 Test St"
+        )
+
+        val rating = 5
+        val content = "This is a test review."
+        val imageUrl = "reviews/test-image.jpg"
+
+        // when
+        val newReview = Review.createNewReview(mockUser, mockPlace, content, rating, imageUrl)
+
+        // then
+        assertThat(newReview).isNotNull()
+
+        assertThat(newReview.id).isNull() // 아직 저장되지 않았으므로 ID는 null이어야 함
+
+        assertThat(newReview.user).isEqualTo(mockUser)
+        assertThat(newReview.place).isEqualTo(mockPlace)
+        assertThat(newReview.content).isEqualTo(content)
+        assertThat(newReview.rating).isEqualTo(rating)
+        assertThat(newReview.imageUrl).isEqualTo(imageUrl)
+    }
+}

--- a/backend/src/test/java/com/backend/petplace/domain/review/servcie/ReviewServiceTest.kt
+++ b/backend/src/test/java/com/backend/petplace/domain/review/servcie/ReviewServiceTest.kt
@@ -1,0 +1,194 @@
+package com.backend.petplace.domain.review.servcie
+
+import com.backend.petplace.domain.place.entity.Category1Type
+import com.backend.petplace.domain.place.entity.Category2Type
+import com.backend.petplace.domain.place.entity.Place
+import com.backend.petplace.domain.place.repository.PlaceRepository
+import com.backend.petplace.domain.point.dto.PlaceInfo
+import com.backend.petplace.domain.point.service.PointService
+import com.backend.petplace.domain.point.type.PointAddResult
+import com.backend.petplace.domain.review.dto.ReviewInfo
+import com.backend.petplace.domain.review.dto.request.ReviewCreateRequest
+import com.backend.petplace.domain.review.dto.response.MyReviewResponse
+import com.backend.petplace.domain.review.entity.Review
+import com.backend.petplace.domain.review.repository.ReviewRepository
+import com.backend.petplace.domain.review.service.ReviewService
+import com.backend.petplace.domain.review.service.S3Service
+import com.backend.petplace.domain.user.entity.User
+import com.backend.petplace.domain.user.repository.UserRepository
+import com.backend.petplace.global.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.ArgumentMatchers.anyLong
+import java.time.LocalDate
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class ReviewServiceTest {
+
+    private fun <T> anyNonNull(): T {
+        return Mockito.any()
+    }
+
+    @InjectMocks
+    lateinit var reviewService: ReviewService
+
+    @Mock
+    lateinit var pointService: PointService
+
+    @Mock
+    lateinit var reviewRepository: ReviewRepository
+
+    @Mock
+    lateinit var userRepository: UserRepository
+
+    @Mock
+    lateinit var placeRepository: PlaceRepository
+
+    @Mock
+    lateinit var s3Service: S3Service
+
+    private lateinit var mockUser: User
+    private lateinit var mockPlace: Place
+    private lateinit var reviewRequest: ReviewCreateRequest
+    private lateinit var mockReview: Review
+
+    @BeforeEach
+    fun setUp() {
+        mockUser = User(
+            id = 1L, email = "testuser@example.com", password = "testpassword123",
+            nickName = "testUser", address = "서울 강남구", zipcode = "01234",
+            addressDetail = "101호"
+        )
+
+        mockPlace = Place(
+            id = 10L, uniqueKey = "PLACE_UK_1", name = "TestPlace",
+            category1 = Category1Type.ETC, category2 = Category2Type.ETC,
+            latitude = 37.5, longitude = 127.0, address = "123 Test St"
+        )
+
+        mockPlace = spy(mockPlace)
+
+        reviewRequest = ReviewCreateRequest(
+            placeId = 10L,
+            content = "Good",
+            rating = 5,
+            s3ImagePath = "reviews/image_test.jpg"
+        )
+
+        mockReview = Review(
+            id = 10L,
+            user = mockUser,
+            place = mockPlace,
+            content = reviewRequest.content!!,
+            rating = reviewRequest.rating!!,
+            imageUrl = reviewRequest.s3ImagePath
+        )
+    }
+
+    @Test
+    @DisplayName("리뷰 생성 및 포인트 적립 로직이 정상적으로 실행되어야 한다")
+    fun createReview_Success() {
+        // given
+        `when`(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser))
+        `when`(placeRepository.findById(anyLong())).thenReturn(Optional.of(mockPlace))
+
+        `when`(reviewRepository.save(anyNonNull())).thenReturn(mockReview)
+        `when`(pointService.addPointsForReview(anyNonNull(), anyNonNull())).thenReturn(PointAddResult.SUCCESS)
+
+        // when
+        val response = reviewService.createReview(mockUser.id!!, reviewRequest)
+
+        // then
+        assertThat(response.reviewId).isEqualTo(10L)
+        assertThat(response.pointResultMessage).isEqualTo(PointAddResult.SUCCESS.message)
+
+        // 핵심 메서드 호출 검증
+        verify(reviewRepository, times(1)).save(anyNonNull())
+        verify(mockPlace, times(1)).updateReviewStats(mockReview.rating)
+        verify(pointService, times(1)).addPointsForReview(mockUser, mockReview)
+    }
+
+    @Test
+    @DisplayName("리뷰 생성 시 유효하지 않은 사용자 ID면 예외를 발생시켜야 한다")
+    fun createReview_UserNotFound_ThrowsException() {
+        // given
+        `when`(userRepository.findById(anyLong())).thenReturn(Optional.empty())
+
+        // when & then
+        assertThrows<BusinessException> { reviewService.createReview(999L, reviewRequest) }
+
+        verify(reviewRepository, never()).save(anyNonNull())
+        verify(pointService, never()).addPointsForReview(anyNonNull(), anyNonNull())
+    }
+
+    @Test
+    @DisplayName("내가 작성한 리뷰 조회 시 CloudFront URL로 변환되어야 한다")
+    fun getMyReviews_Success() {
+        // given
+        val s3Path = "reviews/image.jpg"
+        val expectedFullUrl = "https://cdn.cloudfront.net/reviews/image.jpg"
+
+        val dtoWithS3Path = MyReviewResponse(
+            reviewId = 1L,
+            place = PlaceInfo.from(mockPlace),
+            rating = 5,
+            content = "Great place!",
+            imageUrl = s3Path,
+            createdDate = LocalDate.now(),
+            pointsAwarded = 100
+        )
+
+        `when`(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser))
+        `when`(reviewRepository.findMyReviewsWithProjection(anyNonNull()))
+            .thenReturn(listOf(dtoWithS3Path))
+        `when`(s3Service.getPublicUrl(s3Path)).thenReturn(expectedFullUrl)
+
+        // when
+        val results = reviewService.getMyReviews(mockUser.id!!)
+
+        // then
+        assertThat(results).hasSize(1)
+        assertThat(results[0].imageUrl).isEqualTo(expectedFullUrl)
+        verify(s3Service, times(1)).getPublicUrl(s3Path)
+    }
+
+    @Test
+    @DisplayName("장소별 리뷰 조회 시 CloudFront URL로 변환")
+    fun getReviewByPlace_Success() {
+        // given
+        val s3Path = "reviews/place_image.png"
+        val expectedFullUrl = "https://cdn.cloudfront.net/reviews/place_image.png"
+
+        val dtoWithS3Path = ReviewInfo(
+            reviewId = 2L,
+            userName = "Dummy",
+            content = "Test",
+            rating = 4,
+            imageUrl = s3Path,
+            createdDate = LocalDate.now()
+        )
+
+        `when`(placeRepository.findById(anyLong())).thenReturn(Optional.of(mockPlace))
+        `when`(reviewRepository.findReviewInfosByPlaceWithProjection(anyNonNull()))
+            .thenReturn(listOf(dtoWithS3Path))
+
+        `when`(s3Service.getPublicUrl(s3Path)).thenReturn(expectedFullUrl)
+
+        // when
+        reviewService.getReviewByPlace(mockPlace.id!!)
+
+        // then
+        verify(reviewRepository, times(1)).findReviewInfosByPlaceWithProjection(mockPlace)
+        verify(s3Service, times(1)).getPublicUrl(s3Path)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #48 

## 📝 변경 사항
### AS-IS
- Test: Java-style Assertions와 Lombok `builder()` 패턴으로 테스트 데이터 생성.

- 호환성 문제: Mockito `any()`가` null`을 반환하는 문제로 인해 테스트 환경에서` NullPointerException`이 발생했음.

### TO-BE
1.  단위 테스트 안정화 

  - Mockito Fix: Java Mockito의 `any()` 사용으로 발생하던 NullPointerException을 해결하기 위해 `anyNonNull()` 헬퍼 함수를 도입하여 Non-null 타입의 인자도 안전하게 Mocking 할 수 있게 했습니다.

  - Data Creation: 테스트 데이터 생성 시 User.builder()... 대신 User(email=..., password=...) 형태의 Kotlin Primary Constructor를 사용하여 코드의 가독성을 높였습니다.

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="294" height="50" alt="image" src="https://github.com/user-attachments/assets/e1f7034f-4f15-4c29-9ca1-f1da14c32511" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
🤤 지금 제 상태라 PointService는 내일 아침.. 딸깍.. 해보겠습니다.. 호준님 파이팅..

