### PR TITLE
Migration: PointService 유닛 테스트 코틀린 마이그레이션 및 Mockito 호환성 확보

### DIFF
--- a/backend/src/test/java/com/backend/petplace/domain/point/service/PointServiceTest.kt
+++ b/backend/src/test/java/com/backend/petplace/domain/point/service/PointServiceTest.kt
@@ -1,0 +1,188 @@
+package com.backend.petplace.domain.point.service
+
+import com.backend.petplace.domain.place.entity.Category1Type
+import com.backend.petplace.domain.place.entity.Category2Type
+import com.backend.petplace.domain.place.entity.Place
+import com.backend.petplace.domain.point.repository.PointRepository
+import com.backend.petplace.domain.point.type.PointAddResult
+import com.backend.petplace.domain.point.type.PointPolicy
+import com.backend.petplace.domain.review.entity.Review
+import com.backend.petplace.domain.user.entity.User
+import com.backend.petplace.domain.user.repository.UserRepository
+import com.backend.petplace.global.exception.BusinessException
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class PointServiceTest {
+
+    private fun <T> anyNonNull(): T {
+        return Mockito.any()
+    }
+
+    @InjectMocks
+    lateinit var pointService: PointService
+
+    @Mock
+    lateinit var pointRepository: PointRepository
+
+    @Mock
+    lateinit var userRepository: UserRepository
+
+    @Mock
+    lateinit var mockUser: User
+
+    private lateinit var mockPlace: Place
+    private lateinit var mockReviewWithImage: Review
+    private lateinit var mockReviewWithoutImage: Review
+
+    private val DUMMY_USER_ID = 1L
+    private val DUMMY_PLACE_ID = 1L
+    private val DULT_AMOUNT = 100
+
+    @BeforeEach
+    fun setUp() {
+        // 2. Place 객체 생성 (Mock이 아니므로 그대로 생성)
+        mockPlace = Place(
+            id = DUMMY_PLACE_ID, uniqueKey = "UK1", name = "TestPlace",
+            category1 = Category1Type.ETC, category2 = Category2Type.ETC,
+            latitude = 30.0, longitude = 10.0
+        )
+
+        // 3. Review 객체 생성
+        mockReviewWithImage = Review(
+            id = 1L, user = mockUser, place = mockPlace,
+            content = "Review with image.", rating = 5, imageUrl = "key.jpg"
+        )
+        mockReviewWithoutImage = Review(
+            id = 2L, user = mockUser, place = mockPlace,
+            content = "Review without image.", rating = 4, imageUrl = null
+        )
+    }
+
+    @Test
+    @DisplayName("1-1. 이미지 리뷰 등록 시 100 포인트 정상 적립")
+    fun addPointsForReview_Success_WithImage() {
+        // given
+        `when`(mockUser.id).thenReturn(DUMMY_USER_ID)
+        `when`(mockUser.totalPoint).thenReturn(DULT_AMOUNT)
+
+        val expectedAmount = PointPolicy.REVIEW_PHOTO_POINTS.value
+
+        // Mockito Stubbing (이제 @BeforeEach 밖에서 호출되므로 오류가 해결됨)
+        `when`(pointRepository.existsByUserAndPlaceAndRewardDate(anyNonNull(), anyNonNull(), anyNonNull()))
+            .thenReturn(false)
+        `when`(pointRepository.findTodaysPointsSumByUser(anyNonNull(), anyNonNull())).thenReturn(0)
+
+        // when
+        val result = pointService.addPointsForReview(mockUser, mockReviewWithImage)
+
+        // then
+        assertThat(result).isEqualTo(PointAddResult.SUCCESS)
+        verify(pointRepository, times(1)).save(anyNonNull())
+        verify(mockUser, times(1)).addPoints(expectedAmount)
+    }
+
+    @Test
+    @DisplayName("1-2. 텍스트 리뷰 등록 시 50 포인트가 정상 적립")
+    fun addPointsForReview_Success_WithoutImage() {
+        // given
+        val expectedAmount = PointPolicy.REVIEW_TEXT_POINTS.value
+
+        `when`(pointRepository.existsByUserAndPlaceAndRewardDate(anyNonNull(), anyNonNull(), anyNonNull()))
+            .thenReturn(false)
+        `when`(pointRepository.findTodaysPointsSumByUser(anyNonNull(), anyNonNull())).thenReturn(0)
+
+        // when
+        val result = pointService.addPointsForReview(mockUser, mockReviewWithoutImage)
+
+        // then
+        assertThat(result).isEqualTo(PointAddResult.SUCCESS)
+
+        verify(pointRepository, times(1)).save(anyNonNull())
+        verify(mockUser, times(1)).addPoints(expectedAmount)
+    }
+
+    @Test
+    @DisplayName("1-3. 이미 당일 적립된 장소의 리뷰는 ALREADY_AWARDED 반환")
+    fun addPointsForReview_AlreadyAwarded() {
+        // given
+        `when`(pointRepository.existsByUserAndPlaceAndRewardDate(anyNonNull(), anyNonNull(), anyNonNull()))
+            .thenReturn(true)
+
+        // when
+        val result = pointService.addPointsForReview(mockUser, mockReviewWithImage)
+
+        // then
+        assertThat(result).isEqualTo(PointAddResult.ALREADY_AWARDED)
+
+        verify(pointRepository, never()).save(anyNonNull())
+        verify(mockUser, never()).addPoints(anyInt())
+    }
+
+    @Test
+    @DisplayName("1-4. 일일 적립 한도 초과 시 DAILY_LIMIT_EXCEEDED 반환")
+    fun addPointsForReview_DailyLimitExceeded() {
+        // given
+        val dailyLimit = PointPolicy.DAILY_LIMIT.value
+
+        `when`(pointRepository.existsByUserAndPlaceAndRewardDate(anyNonNull(), anyNonNull(), anyNonNull()))
+            .thenReturn(false)
+
+        // 한도 초과 상황 설정
+        `when`(pointRepository.findTodaysPointsSumByUser(anyNonNull(), anyNonNull())).thenReturn(dailyLimit)
+
+        // when
+        val result = pointService.addPointsForReview(mockUser, mockReviewWithImage)
+
+        // then
+        assertThat(result).isEqualTo(PointAddResult.DAILY_LIMIT_EXCEEDED)
+
+        verify(pointRepository, never()).save(anyNonNull())
+        verify(mockUser, never()).addPoints(anyInt())
+    }
+
+    @Test
+    @DisplayName("2-1. 포인트 내역 조회 시 응답 DTO 정상적 생성")
+    fun getPointHistory_Success() {
+        // given
+        `when`(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser))
+        `when`(pointRepository.findPointHistoryByUser(anyNonNull())).thenReturn(mutableListOf())
+
+        // when
+        pointService.getPointHistory(mockUser.id!!)
+
+        verify(userRepository, times(1)).findById(mockUser.id)
+        verify(pointRepository, times(1)).findPointHistoryByUser(mockUser)
+    }
+
+    @Test
+    @DisplayName("2-2. 포인트 내역 조회 시 사용자가 없으면 예외 발생")
+    fun getPointHistory_UserNotFound() {
+        // given
+        `when`(userRepository.findById(anyLong())).thenReturn(Optional.empty())
+
+        // when & then
+        assertThrows<BusinessException> { pointService.getPointHistory(999L) }
+
+        // verify (예외 발생했으므로 findPointHistoryByUser는 호출되지 않아야 함)
+        verify(pointRepository, never()).findPointHistoryByUser(anyNonNull())
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #50 

## 📝 변경 사항
### AS-IS
- Lombok builder() 패턴 사용으로 테스트 데이터 생성 코드가 장황했으며, 프로덕션 코드 마이그레이션 후 호환성 문제가 발생했습니다.

- Mockito any() 사용 시 Non-null 파라미터에 null이 전달되어 NullPointerException (Misused Argument Matcher) 오류가 발생했습니다.
### TO-BE
1. 테스트 코드 구조 (Kotlin Idioms)

  - Constructor Usage: User.builder()... 대신 User(id=..., email=...) 형태의 Named Arguments를 사용하여 테스트 데이터의 가독성을 극대화했습니다.

  - Property Access: 모든 Getter 호출(mockUser.getId())을 프로퍼티 접근(mockUser.id)으로 변경했습니다.

2. Mockito Null Safety 최종 해결 (Interoperability)

  - anyNonNull Helper: 테스트 클래스 내부에 anyNonNull<T>() 헬퍼 함수를 추가하여, Mockito의 any()를 사용하더라도 Kotlin의 Non-null 타입 요구사항을 만족시키도록 했습니다.

  - Stubbing Fix: when(repo.exists(any()))와 같은 Stubbing 호출이 안전하게 작동하도록 수정했습니다.

3. 테스트 환경 안정화

  - Strictness Adjustment: UnnecessaryStubbingException 오류를 해결하기 위해 테스트 클래스에 @MockitoSettings(strictness = Strictness.LENIENT) 설정을 추가했습니다. (테스트 간 Stubbing 재사용을 위한 조치)
  
## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="622" height="106" alt="image" src="https://github.com/user-attachments/assets/cb45610f-257f-4bbb-899f-f283096aaa09" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
마지막입니다 !


